### PR TITLE
Update dcgm ns & operator default resources

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -72,7 +72,8 @@ jobs:
         env:
           CHANGED_LIST: ${{ steps.list-changed.outputs.changed_list }}
         run: |
-          kubectl create ns llmos-system && kubectl create ns llmos-monitoring-system && kubectl create ns llmos-dashboards
+          kubectl create ns llmos-system && kubectl create ns llmos-monitoring-system && kubectl create ns llmos-dashboards \
+          && kubectl create ns llmos-gpu-stack-system
           ct install --namespace llmos-monitoring-system --config .github/linters/ct.yaml
         if: env.llmos_monitoring_changed == 'true'
      

--- a/charts/llmos-monitoring/Chart.yaml
+++ b/charts/llmos-monitoring/Chart.yaml
@@ -23,7 +23,7 @@ name: llmos-monitoring
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 0.1.3-up66.1.1
+version: 0.1.4-up66.1.1
 appVersion: v0.78.1
 kubeVersion: ">=1.19.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/llmos-monitoring/templates/llmos-monitoring/exporters/nvidia/dcgm-servicemonitor.yaml
+++ b/charts/llmos-monitoring/templates/llmos-monitoring/exporters/nvidia/dcgm-servicemonitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels: {{ include "kube-prometheus-stack.labels" . | nindent 4 }}
   name: dcgm-exporter
-  namespace: {{ .Values.global.llmos.systemNamespace }}
+  namespace: {{ .Values.global.llmos.gpuStackNamespace }}
 spec:
   endpoints:
   - interval: 15s
@@ -24,8 +24,7 @@ spec:
   jobLabel: app
   namespaceSelector:
     matchNames:
-      - "llmos-gpu-stack-system"
-      - {{ .Values.global.llmos.systemNamespace }}
+      - {{ .Values.global.llmos.gpuStackNamespace }}
   selector:
     matchLabels:
       app: nvidia-dcgm-exporter

--- a/charts/llmos-monitoring/values.yaml
+++ b/charts/llmos-monitoring/values.yaml
@@ -211,6 +211,7 @@ global:
     clusterId: "local"
     dashboardsNamespace: &dashboardsNamespace "llmos-dashboards"
     systemNamespace: "llmos-system"
+    gpuStackNamespace: "llmos-gpu-stack-system"
   rbac:
     create: true
 
@@ -2960,13 +2961,13 @@ prometheusOperator:
 
   ## Resource limits & requests
   ##
-  resources: {}
-  # limits:
-  #   cpu: 200m
-  #   memory: 200Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 100Mi
+  resources:
+    limits:
+      cpu: 500m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
 
   ## Operator Environment
   ##  env:


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

#### Description:
- Update dcgm service monitoring to watch `llmos-gpu-stack-system` namespace
- Set default resource limits & requests for the Prometheus operator pod.